### PR TITLE
Remove Gemini API key references

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,0 @@
-# Gemini API Key for AI functionality
-GEMINI_API_KEY=your_gemini_api_key_here

--- a/README.md
+++ b/README.md
@@ -46,11 +46,7 @@ Before you begin, ensure you have the following installed:
     ```
 
 3.  **Set up environment variables**:
-    Create a `.env.local` file in the root directory and set your `GEMINI_API_KEY` if required by any AI Studio features. Refer to `.env.example` for structure.
-    ```
-    # .env.local
-    GEMINI_API_KEY=your_gemini_api_key_here
-    ```
+    Refer to `.env.example` for structure.
 
 4.  **Run the development server**:
     ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,6 @@ services:
       - /app/node_modules
     environment:
       - NODE_ENV=development
-      - GEMINI_API_KEY=${GEMINI_API_KEY}
     restart: unless-stopped
     container_name: solar-power-logger-dev
     profiles:


### PR DESCRIPTION
The Gemini API key is no longer used in this project. This commit removes references to GEMINI_API_KEY from the following files:

- README.md: Removed instructions for setting up the GEMINI_API_KEY.
- .env.example: Removed the GEMINI_API_KEY variable.
- docker-compose.yml: Removed the GEMINI_API_KEY environment variable from the solar-power-dev service.